### PR TITLE
Fix service plan created with Windows OS

### DIFF
--- a/.azure/bicep/webapp.bicep
+++ b/.azure/bicep/webapp.bicep
@@ -13,7 +13,7 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2020-06-01' = {
   sku: {
     name: sku
   }
-  kind: 'app'
+  kind: 'app,linux'
 }
 resource appService 'Microsoft.Web/sites@2020-06-01' = {
   name: webAppName


### PR DESCRIPTION
To fix issue with deployment (#43 ), this change force the service plan to use Linux instead of Windows