### PR TITLE
fix .ado / eshoponweb-ci-dockercompose.yml

### DIFF
--- a/.ado/eshoponweb-ci-dockercompose.yml
+++ b/.ado/eshoponweb-ci-dockercompose.yml
@@ -50,7 +50,7 @@ stages:
         targetType: 'inline'
         script: |
           $var=ConvertFrom-Json '$(acr-json)'
-          $value=$var.loginServer.value
+          $value=$var.acrloginServer.value
           Write-Host "##vso[task.setvariable variable=acrloginserver;]$value"
           echo $acrloginserver
     # docker compose build images


### PR DESCRIPTION
'acr-json' output in my case was:
{"acrLoginServer":{"type":"String","value":"foobar.azurecr.io"}

##[debug]script=$var=ConvertFrom-Json '{"acrLoginServer":{"type":"String","value":"crpp2s2mndgsnky.azurecr.io"}}'
$value=$var.loginServer.value
Write-Host "##vso[task.setvariable variable=acrloginserver;]$value"
echo $acrloginserver
##[debug]runScriptInSeparateScope=false
Generating script.
##[debug]Processed: ##vso[task.logdetail id=f957e5a2-231a-4655-afe7-2ff3e6d526d3;type=command;name=command;]Formatted command: $var=ConvertFrom-Json '{"acrLoginServer":{"type":"String","value":"crpp2s2mndgsnky.azurecr.io"}}'%0A$value=$var.loginServer.value%0AWrite-Host "##vso[task.setvariable variable=acrloginserver;]$value"%0Aecho $acrloginserver
##[debug]Agent.Version=2.213.2
![Screenshot_10](https://user-images.githubusercontent.com/66446550/208269462-77b05dbc-4fdc-4a4f-b1ee-083bfe04edce.png)
