### PR TITLE
Update eshoponweb-ci-dockercompose.yml

### DIFF
--- a/.ado/eshoponweb-ci-dockercompose.yml
+++ b/.ado/eshoponweb-ci-dockercompose.yml
@@ -50,7 +50,7 @@ stages:
         targetType: 'inline'
         script: |
           $var=ConvertFrom-Json '$(acr-json)'
-          $value=$var.loginServer.value
+          $value=$var.acrloginServer.value
           Write-Host "##vso[task.setvariable variable=acrloginserver;]$value"
           echo $acrloginserver
     # docker compose build images


### PR DESCRIPTION
Changing line #53 from:

          $value=$var.loginServer.value

To 
          $value=$var.acrloginServer.value

--The property name is "acrloginserver" in the JSON output and not "loginserver".

Got a case because of this issue. 
The task variable $acrloginserver was not getting set or empty. Hence the Push task was failing. Since the $(acrloginserver) is empty, the push task was trying to push to Docker Hub ([docker.io/library/reponame].

Here is the PowerShell task output:

--------------------------
2023-01-05T12:04:37.4069774Z ##[debug]script=$var=ConvertFrom-Json '{"acrLoginServer":{"type":"String","value":"cr4fusrccm2r62o.azurecr.io"}}' $value=$var.loginServer.value
Write-Host "##vso[task.setvariable variable=acrloginserver;]$value" --------------------------------


Docker Push task was failing with below error:

------------------------------------------------
2023-01-05T12:07:26.6566600Z ##[debug]azureContainerRegistry=undefined .
.
.
2023-01-05T12:07:27.8508596Z [command]/usr/bin/docker push eshoppublicapi 2023-01-05T12:07:27.8712589Z Using default tag: latest 2023-01-05T12:07:27.9336293Z The push refers to repository [docker.io/library/eshoppublicapi] ..
.
.
2023-01-05T12:07:30.1004970Z denied: requested access to the resource is denied 2023-01-05T12:07:30.1020306Z ##[debug]Exit code 1 received from tool '/usr/bin/docker' 2023-01-05T12:07:30.1021693Z ##[debug]STDIO streams have closed for tool '/usr/bin/docker' 2023-01-05T12:07:30.1115638Z ##[error]denied: requested access to the resource is denied.
 ------------------------------------------------

--After making below change in the Powershell task, everything worked fine:

    $value=$var.acrloginServer.value