### PR TITLE
fix: typo in RESOURCE GROUP env var

### DIFF
--- a/.github/workflows/eshoponweb-cicd.yml
+++ b/.github/workflows/eshoponweb-cicd.yml
@@ -5,7 +5,7 @@ name: eShopOnWeb Build and Test
 
 #Environment variables https://docs.github.com/en/actions/learn-github-actions/environment-variables
 env:
-  RESOURCE-GROUP: rg-az400-eshopeonweb-NAME
+  RESOURCE-GROUP: rg-az400-eshoponweb-NAME
   LOCATION: westeurope
   TEMPLATE-FILE: .azure/bicep/webapp.bicep
   SUBSCRIPTION-ID: YOUR-SUBS-ID


### PR DESCRIPTION
There is a Typo in the RESOURCE GROUP environment variable which makes it impossible to finish one of the az-400 exercises where this repository is used