### PR TITLE
Enable dependabot for Github Actions, upgrade existing action tasks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
-        include-prerelease: true
+        dotnet-quality: 'preview'
 
     - name: Build with dotnet
       run: dotnet build ./eShopOnWeb.sln --configuration Release

--- a/.github/workflows/eshoponweb-cicd.yml
+++ b/.github/workflows/eshoponweb-cicd.yml
@@ -21,10 +21,10 @@ jobs:
     - uses: actions/checkout@v4
     #prepare runner for desired .net version SDK
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
-        include-prerelease: true
+        dotnet-quality: 'preview'
     #Build/Test/Publish the .net project
     - name: Build with dotnet
       run: dotnet build ./eShopOnWeb.sln --configuration Release
@@ -34,14 +34,14 @@ jobs:
       run: dotnet publish ./src/Web/Web.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
     # upload the published website code artifacts
     - name: Upload artifact for deployment job
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: .net-app
         path: ${{env.DOTNET_ROOT}}/myapp
         
     # upload the bicep template as artifacts for next job
     - name: Upload artifact for deployment job
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: bicep-template
         path: ${{ env.TEMPLATE-FILE }}
@@ -56,27 +56,27 @@ jobs:
     
     #Download the publish files created in previous job
     - name: Download artifact from build job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: .net-app
         path: .net-app
   
     #Download the bicep templates from previous job
     - name: Download artifact from build job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: bicep-template
         path: bicep-template
         
    #Login in your azure subscription using a service principal (credentials stored as GitHub Secret in repo)
     - name: Azure Login
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
            
     # Deploy Azure WebApp using Bicep file
     - name: deploy
-      uses: azure/arm-deploy@v1
+      uses: azure/arm-deploy@v2
       with:
         subscriptionId: ${{ env.SUBSCRIPTION-ID }}
         resourceGroupName: ${{ env.RESOURCE-GROUP }}
@@ -86,8 +86,7 @@ jobs:
     
     # Publish website to Azure App Service (WebApp)
     - name: Publish Website to WebApp
-      uses: Azure/webapps-deploy@v2
+      uses: Azure/webapps-deploy@v3
       with:
         app-name: ${{ env.WEBAPP-NAME  }}
         package: .net-app
-   

--- a/.github/workflows/richnav.yml
+++ b/.github/workflows/richnav.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Setup .NET
+    - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x

--- a/.github/workflows/richnav.yml
+++ b/.github/workflows/richnav.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: 8.0.x
 
     - name: Build with dotnet
       run: dotnet build ./Everything.sln --configuration Release /bl

--- a/.github/workflows/richnav.yml
+++ b/.github/workflows/richnav.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: '8.0.x'
 
     - name: Build with dotnet
       run: dotnet build ./Everything.sln --configuration Release /bl


### PR DESCRIPTION
Upgrade Github Actions tasks so most of the tasks are on NodeJS20. This due to deprecation of NodeJS16: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Only task that is using NodeJS16 is webapps-deploy@v3. 

Enabled Dependabot updates voor Github Actions, so future updates will be identified earlier/easier.