### PR TITLE
Upgrade Azure Devops tasks to latest versions

### DIFF
--- a/.ado/eshoponweb-cd-webapp-dockercompose.yml
+++ b/.ado/eshoponweb-cd-webapp-dockercompose.yml
@@ -57,20 +57,11 @@ stages:
           echo $appserviceplan
 
     #Replace tokens in Docker Compose file
-    - task: qetza.replacetokens.replacetokens-task.replacetokens@3
+    - task: replacetokens@6
       inputs:
-        targetFiles: 'docker-compose-webapp.yml'
-        encoding: 'auto'
-        writeBOM: true
-        actionOnMissing: 'warn'
-        keepToken: false
-        actionOnNoFiles: 'continue'
-        enableTransforms: false
-        tokenPrefix: '__'
-        tokenSuffix: '__'
-        enableRecursion: false
-        useLegacyPattern: false
-        enableTelemetry: true
+        sources: 'docker-compose-webapp.yml'
+        tokenPattern: 'doubleunderscores'
+        addBOM: true
     #Docker Login into private ACR (TODO alternative, using Docker task and docker ADO Service Connection)
     #Deploy using Docker Compose
     - task: AzureCLI@2

--- a/.ado/eshoponweb-ci-mend.yml
+++ b/.ado/eshoponweb-ci-mend.yml
@@ -45,9 +45,9 @@ stages:
         publishWebProjects: true
         arguments: '-o $(Build.ArtifactStagingDirectory)'
     
-    - task: PublishBuildArtifacts@1
+    - task: PublishPipelineArtifact@1
       displayName: Publish Artifacts ADO - Website
       inputs:
-        pathToPublish: '$(Build.ArtifactStagingDirectory)'
-        artifactName: Website
- 
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifact: 'Website'
+        publishLocation: 'pipeline'

--- a/.ado/eshoponweb-ci.yml
+++ b/.ado/eshoponweb-ci.yml
@@ -41,15 +41,16 @@ stages:
         publishWebProjects: true
         arguments: '-o $(Build.ArtifactStagingDirectory)'
     
-    - task: PublishBuildArtifacts@1
+    - task: PublishPipelineArtifact@1
       displayName: Publish Artifacts ADO - Website
       inputs:
-        pathToPublish: '$(Build.ArtifactStagingDirectory)'
-        artifactName: Website
-    
-    - task: PublishBuildArtifacts@1
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifact: 'Website'
+        publishLocation: 'pipeline'
+
+    - task: PublishPipelineArtifact@1
       displayName: Publish Artifacts ADO - Bicep
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/infra/webapp.bicep'
-        ArtifactName: 'Bicep'
-        publishLocation: 'Container'
+        targetPath: '$(Build.SourcesDirectory)/infra/webapp.bicep'
+        artifact: 'Bicep'
+        publishLocation: 'pipeline'

--- a/.ado/eshoponweb-sonar-ci.yml
+++ b/.ado/eshoponweb-sonar-ci.yml
@@ -56,10 +56,10 @@ stages:
         command: 'publish'
         publishWebProjects: true
         arguments: '-o $(Build.ArtifactStagingDirectory)'
-    
-    - task: PublishBuildArtifacts@1
+
+    - task: PublishPipelineArtifact@1
       displayName: Publish Artifacts ADO - Website
       inputs:
-        pathToPublish: '$(Build.ArtifactStagingDirectory)'
-        artifactName: Website
-    
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifact: 'Website'
+        publishLocation: 'pipeline'


### PR DESCRIPTION
Replace PublishBuildArtifact with PublishPipelineArtifact. Since it's mentioned that this is the preferred way in this issue: https://github.com/MicrosoftDocs/azure-devops-docs/issues/2341#issuecomment-439483135.

Update replaceTokens task to latest version.