### PR TITLE
GitHub actions for CI/CD not publishing web app.

### DIFF
--- a/.github/workflows/eshoponweb-cicd.yml
+++ b/.github/workflows/eshoponweb-cicd.yml
@@ -33,8 +33,8 @@ jobs:
     - name: dotnet publish
       run: |
         dotnet publish ./src/Web/Web.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
-        cd ${{env.DOTNET_ROOT}}
-        zip -r ./app.zip myapp
+        cd ${{env.DOTNET_ROOT}}/myapp
+        zip -r ../app.zip .
     # upload the published website code artifacts
     - name: Upload artifact for deployment job
       uses: actions/upload-artifact@v4

--- a/.github/workflows/eshoponweb-cicd.yml
+++ b/.github/workflows/eshoponweb-cicd.yml
@@ -35,8 +35,6 @@ jobs:
         dotnet publish ./src/Web/Web.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
         cd ${{env.DOTNET_ROOT}}
         zip -r ./app.zip myapp
-    - name: View
-      run: tree
     # upload the published website code artifacts
     - name: Upload artifact for deployment job
       uses: actions/upload-artifact@v4

--- a/.github/workflows/eshoponweb-cicd.yml
+++ b/.github/workflows/eshoponweb-cicd.yml
@@ -33,14 +33,16 @@ jobs:
     - name: dotnet publish
       run: |
         dotnet publish ./src/Web/Web.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
-        zip -r app.zip ${{env.DOTNET_ROOT}}/myapp
-        tree
+        cd ${{env.DOTNET_ROOT}}
+        zip -r ./app.zip myapp
+    - name: View
+      run: tree
     # upload the published website code artifacts
     - name: Upload artifact for deployment job
       uses: actions/upload-artifact@v4
       with:
         name: .net-app
-        path: app.zip
+        path: ${{env.DOTNET_ROOT}}/app.zip
         
     # upload the bicep template as artifacts for next job
     - name: Upload artifact for deployment job

--- a/.github/workflows/eshoponweb-cicd.yml
+++ b/.github/workflows/eshoponweb-cicd.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         dotnet publish ./src/Web/Web.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
         zip -r app.zip ${{env.DOTNET_ROOT}}/myapp
+        tree
     # upload the published website code artifacts
     - name: Upload artifact for deployment job
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Current GitHub workflow results is a success execution, but the app reports

"Your web app is running and waiting for your content. Your web app is live, but we don’t have your content yet. If you’ve already deployed, it could take up to 5 minutes for your content to show up, so come back soon."

The published app.zip file is a nested collection of subfolders (\usr\share\dotnet\myapp\) that results in the Web App not finding the web content. 

This patch corrects the depth of the App contents in the deployed zip file.