### PR TITLE
Update the Webapp.bicep

### DIFF
--- a/infra/webapp.bicep
+++ b/infra/webapp.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 
 var appServicePlanName = toLower('AppServicePlan-${webAppName}')
 
-resource appServicePlan 'Microsoft.Web/serverfarms@2020-06-01' = {
+resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: appServicePlanName
   location: location
   properties: {
@@ -13,9 +13,8 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2020-06-01' = {
   sku: {
     name: sku
   }
-  kind: 'app'
 }
-resource appService 'Microsoft.Web/sites@2020-06-01' = {
+resource appService 'Microsoft.Web/sites@2022-09-01' = {
   name: webAppName
   kind: 'app'
   location: location


### PR DESCRIPTION
Fix #284

This pull request updates the Azure Resource Manager (ARM) templates to use newer API versions for the `Microsoft.Web/serverfarms` and `Microsoft.Web/sites` resources. These changes ensure compatibility with the latest features and improvements provided by Azure.

Updates to ARM templates:

* [`infra/webapp.bicep`](diffhunk://#diff-d2e09e4bf9e02332cbf489c14ac2bb1831bde3c63bcb4c7c85ad9974316e7040L7-R7): Updated the `Microsoft.Web/serverfarms` resource to use the `2022-09-01` API version.
* [`infra/webapp.bicep`](diffhunk://#diff-d2e09e4bf9e02332cbf489c14ac2bb1831bde3c63bcb4c7c85ad9974316e7040L16-R17): Updated the `Microsoft.Web/sites` resource to use the `2022-09-01` API version.