### PR TITLE
Fix Azure deployment failures and .NET 8.0 package compatibility

### DIFF
--- a/.github/workflows/eshoponweb-cicd.yml
+++ b/.github/workflows/eshoponweb-cicd.yml
@@ -5,11 +5,11 @@ on: workflow_dispatch
 
 #Environment variables https://docs.github.com/en/actions/learn-github-actions/environment-variables
 env:
-  RESOURCE-GROUP: rg-eshoponweb-westeurope
+  RESOURCE-GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
   LOCATION: westeurope
   TEMPLATE-FILE: infra/webapp.bicep
   SUBSCRIPTION-ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  WEBAPP-NAME: devops-webapp-westeurope-178376703
+  WEBAPP-NAME: ${{ secrets.AZURE_WEBAPP_NAME }}
 
 
 jobs:
@@ -78,14 +78,29 @@ jobs:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
            
     # Deploy Azure WebApp using Bicep file
-    - name: deploy
-      uses: azure/arm-deploy@v2
+    - name: Deploy infrastructure
+      uses: Azure/cli@v2
       with:
-        subscriptionId: ${{ env.SUBSCRIPTION-ID }}
-        resourceGroupName: ${{ env.RESOURCE-GROUP }}
-        template: bicep-template/webapp.bicep
-        parameters: 'webAppName=${{ env.WEBAPP-NAME }} location=${{ env.LOCATION }}'
-        failOnStdErr: false   
+        inlineScript: |
+          az deployment group create \
+            --name webapp-deployment-${{ github.run_number }} \
+            --resource-group ${{ env.RESOURCE-GROUP }} \
+            --template-file bicep-template/webapp.bicep \
+            --parameters webAppName=${{ env.WEBAPP-NAME }} location=${{ env.LOCATION }} \
+            --output json
+    
+    # Get the Web App Name from deployment output
+    - name: Get WebApp Details
+      id: webapp
+      uses: Azure/cli@v2
+      with:
+        inlineScript: |
+          webAppName=$(az deployment group show \
+            --name webapp-deployment-${{ github.run_number }} \
+            --resource-group ${{ env.RESOURCE-GROUP }} \
+            --query 'properties.outputs.webAppName.value' \
+            --output tsv)
+          echo "webapp-name=$webAppName" >> $GITHUB_OUTPUT
     
     # Publish website to Azure App Service (WebApp)
     # Step disabled due to issue where the site sometimes can't be found: https://github.com/microsoft/pipelines-appservice-lib/issues/56. Instead deploy using CLI
@@ -102,4 +117,4 @@ jobs:
       uses: Azure/cli@v2
       with:
         inlineScript: |
-             az webapp deploy --name ${{ env.WEBAPP-NAME }} --resource-group ${{ env.RESOURCE-GROUP }} --src-path .net-app/app.zip --type zip
+             az webapp deploy --name ${{ steps.webapp.outputs.webapp-name }} --resource-group ${{ env.RESOURCE-GROUP }} --src-path .net-app/app.zip --type zip

--- a/.github/workflows/eshoponweb-cicd.yml
+++ b/.github/workflows/eshoponweb-cicd.yml
@@ -1,15 +1,15 @@
 name: eShopOnWeb Build and Test
 
 #Triggers (uncomment line below to use it)
-#on: [push, workflow_dispatch]
+on: workflow_dispatch
 
 #Environment variables https://docs.github.com/en/actions/learn-github-actions/environment-variables
 env:
-  RESOURCE-GROUP: rg-eshoponweb-NAME
+  RESOURCE-GROUP: rg-eshoponweb-westeurope
   LOCATION: westeurope
   TEMPLATE-FILE: infra/webapp.bicep
-  SUBSCRIPTION-ID: YOUR-SUBS-ID
-  WEBAPP-NAME: eshoponweb-webapp-NAME
+  SUBSCRIPTION-ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  WEBAPP-NAME: devops-webapp-westeurope-178376703
 
 
 jobs:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />
     <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
@@ -52,7 +52,7 @@
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="System.Net.Http.Json" Version="$(SystemExtensionVersion)" />
     <PackageVersion Include="System.Security.Claims" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.8.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.1.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.1" />

--- a/infra/webapp.bicep
+++ b/infra/webapp.bicep
@@ -35,3 +35,7 @@ resource appService 'Microsoft.Web/sites@2022-09-01' = {
     }
   }
 }
+
+output webAppName string = appService.name
+output webAppUrl string = appService.properties.defaultHostName
+output resourceId string = appService.id


### PR DESCRIPTION
This pull request updates the CI/CD workflow and infrastructure provisioning for the eShopOnWeb project, focusing on improved security, automation, and reliability. It also aligns package dependencies to compatible versions. The main changes are grouped below:

**CI/CD Workflow Improvements:**

* Updated `.github/workflows/eshoponweb-cicd.yml` to use GitHub secrets for sensitive environment variables (`RESOURCE-GROUP`, `SUBSCRIPTION-ID`, `WEBAPP-NAME`), enhancing security and flexibility.
* Changed the deployment process to use `Azure/cli@v2` with inline scripts for both infrastructure provisioning and retrieving deployment outputs, replacing the previous `azure/arm-deploy@v2` step. This allows for more control and dynamic retrieval of the deployed web app's name.
* Modified the web app deployment step to use the dynamically retrieved web app name from the previous step, ensuring the correct target for deployment.

**Infrastructure as Code Enhancements:**

* Added outputs (`webAppName`, `webAppUrl`, `resourceId`) to the `infra/webapp.bicep` template, making deployment results available for use in subsequent workflow steps.

**Dependency Management:**

* Downgraded `Microsoft.EntityFrameworkCore.Tools` from version `9.0.4` to `8.0.8` and `System.Text.Json` from `9.0.4` to `8.0.5` in `Directory.Packages.props`, ensuring compatibility with the rest of the codebase. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L44-R44) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L55-R55)